### PR TITLE
fixed hr icon in workspace leaves

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -2886,13 +2886,18 @@ button.copy-code-button {
 /* @ MARKDOWN D1: HR*/
 hr {
     border-width: 2px;
+    overflow: visible;
+}
+
+.workspace-leaf-resize-handle::after {
+    visibility: hidden;
 }
 
 hr::after {
     content: var(--hrcon);
     color: var(--hrcol);
     display: inline-block;
-    position: absolute;
+    position: relative;
     left: 50%;
     transform: var(--hrtrans);
     transform-origin: 50% 50%;

--- a/obsidian.css
+++ b/obsidian.css
@@ -2906,6 +2906,10 @@ hr::after {
     clip-path: polygon(50% 0%, 68% 26%, 98% 35%, 79% 60%, 79% 91%, 51% 78%, 21% 91%, 23% 59%, 2% 35%, 33% 27%);
     }
 
+    .hr.cm-line {
+        padding-top: 15px;
+    }
+
 /* @ MARKDOWN D2: HTML Progress Bar*/
 progress {
     background: none;


### PR DESCRIPTION
Fixed #6 by making hr overflow visible  and hr::after position relative so the icons follow the scrolling action. I also added a rule to not show the icons when it is on a resize bar on a leaf.